### PR TITLE
Oop pdo link db

### DIFF
--- a/phplessons/OOP_Link_Databse.php
+++ b/phplessons/OOP_Link_Databse.php
@@ -1,0 +1,15 @@
+<?php
+    include "./includes/autoloader.inc.php";
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    
+</body>
+</html>

--- a/phplessons/OOP_Link_Databse.php
+++ b/phplessons/OOP_Link_Databse.php
@@ -10,6 +10,9 @@
     <title>Document</title>
 </head>
 <body>
-    
+   <?php
+     $testObj = new Test(); 
+     $testObj->getUsers();
+   ?> 
 </body>
 </html>

--- a/phplessons/classes/Dbh.class.php
+++ b/phplessons/classes/Dbh.class.php
@@ -3,12 +3,12 @@ class Dbh{
     private $servername = "localhost";
     private $username = "luna";
     private $password = "0000";
-    private $dbname = "Mysql";
+    private $dbname = "mysql";
 
         
     protected function connect(){
-        $dsn = 'mysql:host='. $this->servername.';, dbname='. $this->dbname .', '. $this->username .', '.$this->password;
-        $pdo = new PDO($dsn);
+        $dsn = 'mysql:host='. $this->servername.'; dbname='. $this->dbname;
+        $pdo = new PDO($dsn, $this->username, $this->password);
         $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
         return $pdo; 
     }

--- a/phplessons/classes/Dbh.class.php
+++ b/phplessons/classes/Dbh.class.php
@@ -1,0 +1,16 @@
+<?php
+class Dbh{
+    private $servername = "localhost";
+    private $username = "luna";
+    private $password = "0000";
+    private $dbname = "Mysql";
+
+        
+    protected function connect(){
+        $dsn = 'mysql:host='. $this->servername.';, dbname='. $this->dbname .', '. $this->username .', '.$this->password;
+        $pdo = new PDO($dsn);
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+        return $pdo; 
+    }
+
+}

--- a/phplessons/classes/Test.class.php
+++ b/phplessons/classes/Test.class.php
@@ -1,0 +1,11 @@
+<?php
+class Test extends Dbh{
+
+    public function getUsers(){
+       $sql = 'SELECT * FROM user';
+       $stmt = $this->connect()->query($sql);
+       while($row = $stmt->fetch()){
+         echo $row['User'].PHP_EOL; 
+       }
+    }
+}

--- a/phplessons/includes/autoloader.inc.php
+++ b/phplessons/includes/autoloader.inc.php
@@ -2,7 +2,8 @@
 spl_autoload_register('myAutoLoader');
 
 function myAutoLoader($className){
-    /* no trns webpage
+    // no trns webpage
+
     $path = './classes/';
     $extension = '.class.php';
     $fullPath = $path. $className . $extension;
@@ -12,9 +13,10 @@ function myAutoLoader($className){
     }
 
     include_once $fullPath;
-    */
+    
 
     // trns webpage
+    /*
     $url = $_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
 
     if (strpos($url, 'includes')!== false){
@@ -29,6 +31,6 @@ function myAutoLoader($className){
     $fullPath = $path. $className . $extension;
 
     require_once $fullPath;
-
+    */
 }
 


### PR DESCRIPTION
# 使用 OOP ＆ PDO 的方式與資料庫連線
- notice: 
  - DBname 大小寫要注意
  - PDO(param1, param2, param3) ，param1 ~ 3 存在既有的格式需遵照 <sub> -參考 [PHP manual:  PDO::__construct](https://www.php.net/manual/en/pdo.construct.php)</sub>

## setAttribute() 設定資料庫屬性的方法
- PDO::ATTR_DEFAULT_FETCH_MODE
**Set the default fetch mode.** A description of the modes and how to use them is available in the [PDOStatement::fetch()](https://www.php.net/manual/en/pdostatement.fetch.php) documentation.
- PDO::FETCH_ASSOC: returns an array indexed by column name as returned in your result set
- 在 connect() 設置取得『資料庫屬性的方法』，透過 PDO::query 將資料庫的內容秀在頁面上

參考：
[PDO::query](https://www.php.net/manual/en/pdo.query.php)
參考影片：
[17: Query A Database Using OOP PHP](https://youtu.be/T41SMNgyRrc)