### PR TITLE
feat:[Docker] Ruby in Docker

### DIFF
--- a/helloDocker/Dockerfile
+++ b/helloDocker/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.7.6-alpine
+
+RUN mkdir -p /usr/src
+WORKDIR /usr/src
+
+COPY . /usr/src
+
+CMD [ "ruby", "hello.rb" ]

--- a/helloDocker/hello.rb
+++ b/helloDocker/hello.rb
@@ -1,0 +1,5 @@
+def sayhi
+  puts "hello, bro!"
+end
+
+sayhi();


### PR DESCRIPTION
# Use  Docker  Run Ruby  
## 前情提要
安裝 docker 幾經輾轉，雖然 MAC 可以使用 Docker ，考量到後續可能把自個的 MAC 玩壞，決定在 VM 裡的 Ubuntu 建立 Docker 來玩，猶於是在 M1 架構下的 VM，想當然是無法安裝 Docker Desktop for Ubuntu 的版本。
直接用 Docker Engine，入坑了。

## 不用 sudo 可行嗎？
每每在下 docker 指令，都得搭配著 `sudo` 一起使用，`sudo docker` 用久之後，發覺我自己都是 administer..
我找到了，可以直接使用 `docker` 下指令的方法

![](https://i.imgur.com/ixKeGTq.jpg)
1. 建立一名稱為 docker 的 group: `sudo groupadd docker`
![](https://i.imgur.com/L2JcK64.jpg)</br>
2. 將使用者加入 docker 的 group: `sudo gpasswd -a $USER docker`
![](https://i.imgur.com/sdoZVHL.jpg)</br>
3. 登出/登入 使用者 or 執行`newgrp docker`</br>
4. Congratulations！ 不在使用 `sudo`
![](https://i.imgur.com/VYahjRW.jpg)</br>
參考：
[How can I use docker without sudo?](https://askubuntu.com/questions/477551/how-can-i-use-docker-without-sudo)

***
## Use docker run ruby
- Notice:
    - name of the dockerfile is just **`Dockerfile`** with a capital D and no extension at the end of it. 
- 格式簡介:
    - <font color=#00f>`FROM [repository]/[image]:[version]`</font>  instruction specifies the **Parent Image** from which you are building. 
    - <font color="#00f">`RUN <command>`</font>  *shell* form, the command is run in a shell
        - To actually **publish the port** when running the container, use the **-p** flag on docker run to publish and map one or more port
    - <font color="#00f">`WORKDIR [path]`</font> 用來設定 Container 內的預設工作路徑
    - <font color="#00f">`COPY [file_path] [container_path]`</font> 複製本地路徑的 file (`.`) 到 Container (`/usr/src/app`) 內 
    - <font color="#00f">`CMD ["param1", "param2"]`</font>  CMD 的三種格式之一，用來提供 ENTRYPOINT 的預設參數 
        - There can only be one CMD instruction in a Dockerfile. If you list more than one CMD then *only the last CMD will take effect*.
        - 為正在執行的 container 提供默認值 
```dockerfile
# 用 Docker 建立一個 ruby 的執行環境
# 在環境內，用 ruby 執行 hello.rb
FROM ruby:2.7.6-alpine
RUN mkdir -p /usr/src/app
WORKDIR /usr/src/app
COPY . /usr/src/app
CMD [ "ruby", "hello.rb" ]
```
參考：
[Day-5 煉成 Docker Image](https://ithelp.ithome.com.tw/articles/10240510)
[Dockerfile reference](https://docs.docker.com/engine/reference/builder/)
***
## why use /usr/src create app of folder in docker?
我說資料夾那麼多，怎麼大夥的範例，都要把 container 放在 `/usr/src` 或 `/usr/local/src` 裡邊放呢！
- notice: **usr 是Unix Software Resource 的縮寫**，~~user 的縮寫~~
- `/usr/local` 系統管理員在本機自行安裝自己下載的軟體(非distribution預設提供者)，建議安裝到此目錄 ~-取自鳥哥~
- `/usr/src`  一般原始碼建議放置到這裡，src 有 source 的意思。 ~-取自鳥哥~

難怪大夥都把 docker build container 放在 `/usr/src` 或 `/usr/local/src` 的路徑底下
參考：
[/usr 的意義與內容](https://linux.vbird.org/linux_basic/centos7/0210filepermission.php#dir_fhs_usr)
